### PR TITLE
[Fix]: Logs convetions monitoring example

### DIFF
--- a/conventions/logs.conventions.md
+++ b/conventions/logs.conventions.md
@@ -54,7 +54,6 @@ class SomeClass {
       await usersService
         .updateUser()
         .finally(() => logger.endStep(STEPS.UPDATE_USER));
-      logger.endStep(STEPS.UPDATE_USER);
       logger.startStep(STEPS.NOTIFY_USER, logGroup);
       await usersService
         .notifyUser()


### PR DESCRIPTION
This pull request makes a minor improvement to the logging conventions in `conventions/logs.conventions.md`. The redundant call to `logger.endStep(STEPS.UPDATE_USER)` has been removed, ensuring that the step completion is only logged once after the user update operation.